### PR TITLE
Mispelling in Objective-C initialization

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
@@ -7,7 +7,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    // initalise property's default value, if any
+    // initialize property's default value, if any
     {{#vars}}{{#defaultValue}}self.{{name}} = {{{defaultValue}}};
     {{/defaultValue}}{{/vars}}
   }


### PR DESCRIPTION
initalise=> initialize